### PR TITLE
Make Bukkit permission children be a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ bukkit {
     
     permissions {
         'testplugin.*' {
-            children = ['testplugin.test']
+            children = ['testplugin.test'] // Defaults permissions to true
+            // You can also specify the values of the permissions
+            childrenMap = ['testplugin.test': false]
         }
         'testplugin.test' {
             description = 'Allows you to run the test command'
@@ -118,7 +120,9 @@ bukkit {
     
     permissions {
         "testplugin.*" {
-            children = listOf("testplugin.test")
+            children = listOf("testplugin.test") // Defaults permissions to true
+            // You can also specify the values of the permissions
+            childrenMap = mapOf("testplugin.test" to true)
         }
         "testplugin.test" {
             description = "Allows you to run the test command"

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
@@ -78,7 +78,12 @@ class BukkitPluginDescription(project: Project) : Serializable {
     data class Permission(@Transient @JsonIgnore val name: String) : Serializable {
         var description: String? = null
         var default: Default? = null
-        var children: List<String>? = null
+        var children: List<String>? // No @[Transient JsonIgnore] needed as it has no backing value
+            get() = childrenMap?.filterValues { it }?.keys?.toList()
+            set(value) {
+                childrenMap = value?.map { it to true }?.toMap()
+            }
+        @JsonProperty("children") var childrenMap: Map<String, Boolean>? = null
 
         enum class Default {
             @JsonProperty("true")   TRUE,


### PR DESCRIPTION
Fixes #5 

This makes the Bukkit permission children be a map instead of a list.

Code which says this is the case: https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java#169-172