### PR TITLE
Add libraries support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ plugins {
     id 'net.minecrell.plugin-yml.bukkit' version '0.4.0'
 }
 
+dependencies {
+    // Downloaded from Maven Central when the plugin is loaded
+    library 'com.google.code.gson:gson:2.8.7' // All platforms
+    bukkitLibrary 'com.google.code.gson:gson:2.8.7' // Bukkit only
+}
+
 bukkit {
     // Default values can be overridden if needed
     // name = 'TestPlugin'
@@ -83,6 +89,13 @@ bukkit {
 ```kotlin
 plugins {
     id("net.minecrell.plugin-yml.bukkit") version "0.4.0"
+}
+
+dependencies {
+    // Downloaded from Maven Central when the plugin is loaded
+    library(kotlin("stdlib")) // All platforms
+    library("com.google.code.gson", "gson", "2.8.7") // All platforms
+    bukkitLibrary("com.google.code.gson", "gson", "2.8.7") // Bukkit only
 }
 
 bukkit {
@@ -145,6 +158,12 @@ plugins {
     id 'net.minecrell.plugin-yml.bungee' version '0.4.0'
 }
 
+dependencies {
+    // Downloaded from Maven Central when the plugin is loaded
+    library 'com.google.code.gson:gson:2.8.7' // All platforms
+    bungeeLibrary 'com.google.code.gson:gson:2.8.7' // Bungee only
+}
+
 bungee {
     // Default values can be overridden if needed
     // name = 'TestPlugin'
@@ -168,6 +187,13 @@ bungee {
 ```kotlin
 plugins {
     id("net.minecrell.plugin-yml.bungee") version "0.4.0"
+}
+
+dependencies {
+    // Downloaded from Maven Central when the plugin is loaded
+    library(kotlin("stdlib")) // All platforms
+    library("com.google.code.gson", "gson", "2.8.7") // All platforms
+    bungeeLibrary("com.google.code.gson", "gson", "2.8.7") // Bungee only
 }
 
 bungee {

--- a/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
@@ -40,7 +40,7 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
 
     protected open fun createConfiguration(project: Project): Configuration? {
         val library = project.configurations.maybeCreate("library")
-        return project.configurations.create("${platformName}Library").extendsFrom(library)
+        return project.configurations.create("${platformName.decapitalize()}Library").extendsFrom(library)
     }
 
     final override fun apply(project: Project) {

--- a/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
@@ -26,6 +26,7 @@ package net.minecrell.pluginyml
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.kotlin.dsl.register
 import org.gradle.api.tasks.SourceSet
@@ -36,6 +37,7 @@ import org.gradle.kotlin.dsl.withType
 abstract class PlatformPlugin<T : PluginDescription>(private val platformName: String, private val fileName: String) : Plugin<Project> {
 
     protected abstract fun createExtension(project: Project): T
+    protected abstract fun createConfiguration(project: Project): Configuration?
 
     final override fun apply(project: Project) {
         project.run {
@@ -46,12 +48,15 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
 
             val generatedResourcesDirectory = layout.buildDirectory.dir("generated/plugin-yml/$platformName")
 
+            // Add library configuration
+            val libraries = createConfiguration(this)
+
             // Create task
             val generateTask = tasks.register<GeneratePluginDescription>("generate${platformName}PluginDescription") {
                 fileName.set(this@PlatformPlugin.fileName)
                 outputDirectory.set(generatedResourcesDirectory)
                 pluginDescription.set(provider {
-                    setDefaults(project, description)
+                    setDefaults(project, libraries, description)
                     description
                 })
 
@@ -68,7 +73,7 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
         }
     }
 
-    protected abstract fun setDefaults(project: Project, description: T)
+    protected abstract fun setDefaults(project: Project, libraries: Configuration?, description: T)
     protected abstract fun validate(description: T)
 
 }

--- a/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
@@ -37,7 +37,11 @@ import org.gradle.kotlin.dsl.withType
 abstract class PlatformPlugin<T : PluginDescription>(private val platformName: String, private val fileName: String) : Plugin<Project> {
 
     protected abstract fun createExtension(project: Project): T
-    protected abstract fun createConfiguration(project: Project): Configuration?
+
+    protected open fun createConfiguration(project: Project): Configuration? {
+        val library = project.configurations.maybeCreate("library")
+        return project.configurations.create("${platformName}Library").extendsFrom(library)
+    }
 
     final override fun apply(project: Project) {
         project.run {
@@ -68,6 +72,7 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
             plugins.withType<JavaPlugin> {
                 extensions.getByType<SourceSetContainer>().named(SourceSet.MAIN_SOURCE_SET_NAME) {
                     resources.srcDir(generateTask)
+                    configurations.getByName(compileClasspathConfigurationName).extendsFrom(libraries)
                 }
             }
         }

--- a/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
@@ -72,7 +72,9 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
             plugins.withType<JavaPlugin> {
                 extensions.getByType<SourceSetContainer>().named(SourceSet.MAIN_SOURCE_SET_NAME) {
                     resources.srcDir(generateTask)
-                    configurations.getByName(compileClasspathConfigurationName).extendsFrom(libraries)
+                    if (libraries != null) {
+                        configurations.getByName(compileClasspathConfigurationName).extendsFrom(libraries)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
@@ -27,6 +27,7 @@ package net.minecrell.pluginyml.bukkit
 import net.minecrell.pluginyml.InvalidPluginDescriptionException
 import net.minecrell.pluginyml.PlatformPlugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 
 class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.yml") {
 
@@ -36,12 +37,21 @@ class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.y
 
     override fun createExtension(project: Project) = BukkitPluginDescription(project)
 
-    override fun setDefaults(project: Project, description: BukkitPluginDescription) {
+    override fun createConfiguration(project: Project): Configuration {
+        val library = project.configurations.maybeCreate("library")
+        val platformLibrary = project.configurations.maybeCreate("bukkitLibrary").extendsFrom(library)
+        project.configurations.maybeCreate("compileClasspath").extendsFrom(platformLibrary)
+        return platformLibrary
+    }
+
+    override fun setDefaults(project: Project, libraries: Configuration?, description: BukkitPluginDescription) {
         description.name = description.name ?: project.name
         description.version = description.version ?: project.version.toString()
         description.description = description.description ?: project.description
         description.website = description.website ?: project.findProperty("url")?.toString()
         description.author = description.author ?: project.findProperty("author")?.toString()
+        description.libraries = description.libraries ?: libraries!!.resolvedConfiguration.resolvedArtifacts
+            .map { it.id.componentIdentifier.toString() }
     }
 
     override fun validate(description: BukkitPluginDescription) {

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
@@ -43,8 +43,8 @@ class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.y
         description.description = description.description ?: project.description
         description.website = description.website ?: project.findProperty("url")?.toString()
         description.author = description.author ?: project.findProperty("author")?.toString()
-        description.libraries = description.libraries ?: libraries!!.resolvedConfiguration.resolvedArtifacts
-            .map { it.id.componentIdentifier.toString() }
+        description.libraries = description.libraries ?: libraries!!.resolvedConfiguration.firstLevelModuleDependencies
+            .map { it.module.id.toString() }
     }
 
     override fun validate(description: BukkitPluginDescription) {

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
@@ -37,13 +37,6 @@ class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.y
 
     override fun createExtension(project: Project) = BukkitPluginDescription(project)
 
-    override fun createConfiguration(project: Project): Configuration {
-        val library = project.configurations.maybeCreate("library")
-        val platformLibrary = project.configurations.maybeCreate("bukkitLibrary").extendsFrom(library)
-        project.configurations.maybeCreate("compileClasspath").extendsFrom(platformLibrary)
-        return platformLibrary
-    }
-
     override fun setDefaults(project: Project, libraries: Configuration?, description: BukkitPluginDescription) {
         description.name = description.name ?: project.name
         description.version = description.version ?: project.version.toString()

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
@@ -52,6 +52,7 @@ class BukkitPluginDescription(project: Project) : PluginDescription {
     @Input @Optional var prefix: String? = null
     @Input @Optional @JsonProperty("default-permission") var defaultPermission: Permission.Default? = null
     @Input @Optional var provides: List<String>? = null
+    @Input @Optional var libraries: List<String>? = null
 
     @Nested val commands: NamedDomainObjectContainer<Command> = project.container(Command::class.java)
     @Nested val permissions: NamedDomainObjectContainer<Permission> = project.container(Permission::class.java)

--- a/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
@@ -33,13 +33,6 @@ class BungeePlugin : PlatformPlugin<BungeePluginDescription>("Bungee", "bungee.y
 
     override fun createExtension(project: Project) = BungeePluginDescription()
 
-    override fun createConfiguration(project: Project): Configuration {
-        val library = project.configurations.maybeCreate("library")
-        val platformLibrary = project.configurations.maybeCreate("bungeeLibrary").extendsFrom(library)
-        project.configurations.maybeCreate("compileClasspath").extendsFrom(platformLibrary)
-        return platformLibrary
-    }
-
     override fun setDefaults(project: Project, libraries: Configuration?, description: BungeePluginDescription) {
         description.name = description.name ?: project.name
         description.version = description.version ?: project.version.toString()

--- a/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
@@ -27,16 +27,26 @@ package net.minecrell.pluginyml.bungee
 import net.minecrell.pluginyml.InvalidPluginDescriptionException
 import net.minecrell.pluginyml.PlatformPlugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 
 class BungeePlugin : PlatformPlugin<BungeePluginDescription>("Bungee", "bungee.yml") {
 
     override fun createExtension(project: Project) = BungeePluginDescription()
 
-    override fun setDefaults(project: Project, description: BungeePluginDescription) {
+    override fun createConfiguration(project: Project): Configuration {
+        val library = project.configurations.maybeCreate("library")
+        val platformLibrary = project.configurations.maybeCreate("bungeeLibrary").extendsFrom(library)
+        project.configurations.maybeCreate("compileClasspath").extendsFrom(platformLibrary)
+        return platformLibrary
+    }
+
+    override fun setDefaults(project: Project, libraries: Configuration?, description: BungeePluginDescription) {
         description.name = description.name ?: project.name
         description.version = description.version ?: project.version.toString()
         description.description = description.description ?: project.description
         description.author = description.author ?: project.findProperty("author")?.toString()
+        description.libraries = description.libraries ?: libraries!!.resolvedConfiguration.resolvedArtifacts
+            .map { it.id.componentIdentifier.toString() }
     }
 
     override fun validate(description: BungeePluginDescription) {

--- a/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
@@ -38,8 +38,8 @@ class BungeePlugin : PlatformPlugin<BungeePluginDescription>("Bungee", "bungee.y
         description.version = description.version ?: project.version.toString()
         description.description = description.description ?: project.description
         description.author = description.author ?: project.findProperty("author")?.toString()
-        description.libraries = description.libraries ?: libraries!!.resolvedConfiguration.resolvedArtifacts
-            .map { it.id.componentIdentifier.toString() }
+        description.libraries = description.libraries ?: libraries!!.resolvedConfiguration.firstLevelModuleDependencies
+            .map { it.module.id.toString() }
     }
 
     override fun validate(description: BungeePluginDescription) {

--- a/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePluginDescription.kt
@@ -36,4 +36,5 @@ class BungeePluginDescription : PluginDescription {
     @Input @Optional var depends: Set<String>? = null
     @Input @Optional var softDepends: Set<String>? = null
     @Input @Optional var description: String? = null
+    @Input @Optional var libraries: List<String>? = null
 }

--- a/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPlugin.kt
@@ -27,11 +27,16 @@ package net.minecrell.pluginyml.nukkit
 import net.minecrell.pluginyml.InvalidPluginDescriptionException
 import net.minecrell.pluginyml.PlatformPlugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 
 class NukkitPlugin : PlatformPlugin<NukkitPluginDescription>("Nukkit", "nukkit.yml") {
     override fun createExtension(project: Project) = NukkitPluginDescription(project)
 
-    override fun setDefaults(project: Project, description: NukkitPluginDescription) {
+    override fun createConfiguration(project: Project): Configuration? {
+        return null
+    }
+
+    override fun setDefaults(project: Project, libraries: Configuration?, description: NukkitPluginDescription) {
         description.name = description.name ?: project.name
         description.version = description.version ?: project.version.toString()
         description.description = description.description ?: project.description


### PR DESCRIPTION
Adds `library`, `bukkitLibrary` and `bungeeLibrary` dependency configurations.

Specifying a dependency like this:
```kotlin
dependencies {
    library(kotlin("stdlib"))
}
```
generates this output:
```yaml
libraries:
 - org.jetbrains.kotlin:kotlin-stdlib:1.5.20
```
Alternatively, `libraries` can be configured manually in the build script:
```yaml
bukkit {
    // ...
    libraries = listOf(
        "org.jetbrains.kotlin:kotlin-stdlib:1.5.20"
    )
}
```

Closes #11 