### PR TITLE
Resolve library dependencies during generation

### DIFF
--- a/src/main/kotlin/net/minecrell/pluginyml/GeneratePluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/GeneratePluginDescription.kt
@@ -35,10 +35,12 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.gradle.api.DefaultTask
 import org.gradle.api.NamedDomainObjectCollection
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.property
@@ -47,6 +49,10 @@ open class GeneratePluginDescription : DefaultTask() {
 
     @Input
     val fileName: Property<String> = project.objects.property()
+
+    @Input
+    @Optional
+    val librariesConfiguration: Property<Configuration> = project.objects.property()
 
     @Nested
     val pluginDescription: Property<PluginDescription> = project.objects.property()

--- a/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
@@ -58,13 +58,15 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
             // Create task
             val generateTask = tasks.register<GeneratePluginDescription>("generate${platformName}PluginDescription") {
                 fileName.set(this@PlatformPlugin.fileName)
+                librariesConfiguration.set(libraries)
                 outputDirectory.set(generatedResourcesDirectory)
                 pluginDescription.set(provider {
-                    setDefaults(project, libraries, description)
+                    setDefaults(project, description)
                     description
                 })
 
                 doFirst {
+                    resolve(librariesConfiguration.orNull, description)
                     validate(description)
                 }
             }
@@ -80,7 +82,8 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
         }
     }
 
-    protected abstract fun setDefaults(project: Project, libraries: Configuration?, description: T)
+    protected abstract fun setDefaults(project: Project, description: T)
+    protected abstract fun resolve(libraries: Configuration?, description: T)
     protected abstract fun validate(description: T)
 
 }

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
@@ -37,12 +37,15 @@ class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.y
 
     override fun createExtension(project: Project) = BukkitPluginDescription(project)
 
-    override fun setDefaults(project: Project, libraries: Configuration?, description: BukkitPluginDescription) {
+    override fun setDefaults(project: Project, description: BukkitPluginDescription) {
         description.name = description.name ?: project.name
         description.version = description.version ?: project.version.toString()
         description.description = description.description ?: project.description
         description.website = description.website ?: project.findProperty("url")?.toString()
         description.author = description.author ?: project.findProperty("author")?.toString()
+    }
+
+    override fun resolve(libraries: Configuration?, description: BukkitPluginDescription) {
         description.libraries = description.libraries ?: libraries!!.resolvedConfiguration.firstLevelModuleDependencies
             .map { it.module.id.toString() }
     }

--- a/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
@@ -33,11 +33,14 @@ class BungeePlugin : PlatformPlugin<BungeePluginDescription>("Bungee", "bungee.y
 
     override fun createExtension(project: Project) = BungeePluginDescription()
 
-    override fun setDefaults(project: Project, libraries: Configuration?, description: BungeePluginDescription) {
+    override fun setDefaults(project: Project, description: BungeePluginDescription) {
         description.name = description.name ?: project.name
         description.version = description.version ?: project.version.toString()
         description.description = description.description ?: project.description
         description.author = description.author ?: project.findProperty("author")?.toString()
+    }
+
+    override fun resolve(libraries: Configuration?, description: BungeePluginDescription) {
         description.libraries = description.libraries ?: libraries!!.resolvedConfiguration.firstLevelModuleDependencies
             .map { it.module.id.toString() }
     }

--- a/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPlugin.kt
@@ -36,12 +36,15 @@ class NukkitPlugin : PlatformPlugin<NukkitPluginDescription>("Nukkit", "nukkit.y
         return null
     }
 
-    override fun setDefaults(project: Project, libraries: Configuration?, description: NukkitPluginDescription) {
+    override fun setDefaults(project: Project, description: NukkitPluginDescription) {
         description.name = description.name ?: project.name
         description.version = description.version ?: project.version.toString()
         description.description = description.description ?: project.description
         description.website = description.website ?: project.findProperty("url")?.toString()
         description.author = description.author ?: project.findProperty("author")?.toString()
+    }
+
+    override fun resolve(libraries: Configuration?, description: NukkitPluginDescription) {
     }
 
     override fun validate(description: NukkitPluginDescription) {


### PR DESCRIPTION
Previously, we resolved the libraries in setDefaults. However, this seems to evaluate the task properties and call setDefaults again recursively, causing a StackOverflowError, so now we do it during the task execution instead.

Adds a library configuration property to the task so the task isn't up-to-date if the libraries were changed.

Fixes #20