### PR TITLE
Use compileOnly instead of compileClasspath for libraries

### DIFF
--- a/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
@@ -73,7 +73,7 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
                 extensions.getByType<SourceSetContainer>().named(SourceSet.MAIN_SOURCE_SET_NAME) {
                     resources.srcDir(generateTask)
                     if (libraries != null) {
-                        configurations.getByName(compileClasspathConfigurationName).extendsFrom(libraries)
+                        configurations.getByName(compileOnlyConfigurationName).extendsFrom(libraries)
                     }
                 }
             }


### PR DESCRIPTION
The Kotlin plugin looks at the `compileOnly` configuration to determine whether there is a dependency on the stdlib yet. This caused the stdlib to be shaded even if it was in the `library` configuration.

Fixes #17