### PR TITLE
Update for Gradle 8 compatibility

### DIFF
--- a/src/main/kotlin/net/minecrell/pluginyml/GeneratePluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/GeneratePluginDescription.kt
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.gradle.api.DefaultTask
 import org.gradle.api.NamedDomainObjectCollection
-import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -51,7 +51,7 @@ abstract class GeneratePluginDescription : DefaultTask() {
 
     @get:Input
     @get:Optional
-    abstract val librariesConfiguration: Property<Configuration>
+    abstract val librariesRootComponent: Property<ResolvedComponentResult>
 
     @get:Nested
     abstract val pluginDescription: Property<PluginDescription>

--- a/src/main/kotlin/net/minecrell/pluginyml/GeneratePluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/GeneratePluginDescription.kt
@@ -43,22 +43,21 @@ import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.kotlin.dsl.property
 
-open class GeneratePluginDescription : DefaultTask() {
+abstract class GeneratePluginDescription : DefaultTask() {
 
-    @Input
-    val fileName: Property<String> = project.objects.property()
+    @get:Input
+    abstract val fileName: Property<String>
 
-    @Input
-    @Optional
-    val librariesConfiguration: Property<Configuration> = project.objects.property()
+    @get:Input
+    @get:Optional
+    abstract val librariesConfiguration: Property<Configuration>
 
-    @Nested
-    val pluginDescription: Property<PluginDescription> = project.objects.property()
+    @get:Nested
+    abstract val pluginDescription: Property<PluginDescription>
 
-    @OutputDirectory
-    val outputDirectory: DirectoryProperty = project.objects.directoryProperty()
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
 
     @TaskAction
     fun generate() {

--- a/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/PlatformPlugin.kt
@@ -27,6 +27,7 @@ package net.minecrell.pluginyml
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.kotlin.dsl.register
 import org.gradle.api.tasks.SourceSet
@@ -58,7 +59,7 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
             // Create task
             val generateTask = tasks.register<GeneratePluginDescription>("generate${platformName}PluginDescription") {
                 fileName.set(this@PlatformPlugin.fileName)
-                librariesConfiguration.set(libraries)
+                librariesRootComponent.set(libraries?.incoming?.resolutionResult?.root)
                 outputDirectory.set(generatedResourcesDirectory)
                 pluginDescription.set(provider {
                     setDefaults(project, description)
@@ -66,7 +67,7 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
                 })
 
                 doFirst {
-                    resolve(librariesConfiguration.orNull, description)
+                    setLibraries(librariesRootComponent.orNull, description)
                     validate(description)
                 }
             }
@@ -83,7 +84,7 @@ abstract class PlatformPlugin<T : PluginDescription>(private val platformName: S
     }
 
     protected abstract fun setDefaults(project: Project, description: T)
-    protected abstract fun resolve(libraries: Configuration?, description: T)
+    protected abstract fun setLibraries(libraries: ResolvedComponentResult?, description: T)
     protected abstract fun validate(description: T)
 
 }

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
@@ -50,7 +50,7 @@ class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.y
         val resolved = libraries?.let {
             it.dependencies.map { d -> (d as? ResolvedDependencyResult)?.selected?.moduleVersion?.toString() ?: error("No moduleVersion for $d") }
         }
-        description.libraries = (description.libraries ?: listOf()) + (resolved ?: listOf())
+        description.libraries = ((description.libraries ?: listOf()) + (resolved ?: listOf())).distinct()
     }
 
     override fun validate(description: BukkitPluginDescription) {

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
@@ -27,7 +27,8 @@ package net.minecrell.pluginyml.bukkit
 import net.minecrell.pluginyml.InvalidPluginDescriptionException
 import net.minecrell.pluginyml.PlatformPlugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 
 class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.yml") {
 
@@ -45,13 +46,11 @@ class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.y
         description.author = description.author ?: project.findProperty("author")?.toString()
     }
 
-    override fun resolve(libraries: Configuration?, description: BukkitPluginDescription) {
-        description.libraries = (
-                (description.libraries ?: listOf()) + libraries!!
-                    .resolvedConfiguration
-                    .firstLevelModuleDependencies
-                    .map { it.module.id.toString() }
-                )
+    override fun setLibraries(libraries: ResolvedComponentResult?, description: BukkitPluginDescription) {
+        val resolved = libraries?.let {
+            it.dependencies.map { d -> (d as? ResolvedDependencyResult)?.selected?.moduleVersion?.toString() ?: error("No moduleVersion for $d") }
+        }
+        description.libraries = (description.libraries ?: listOf()) + (resolved ?: listOf())
     }
 
     override fun validate(description: BukkitPluginDescription) {

--- a/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
@@ -27,7 +27,8 @@ package net.minecrell.pluginyml.bungee
 import net.minecrell.pluginyml.InvalidPluginDescriptionException
 import net.minecrell.pluginyml.PlatformPlugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 
 class BungeePlugin : PlatformPlugin<BungeePluginDescription>("Bungee", "bungee.yml") {
 
@@ -40,13 +41,11 @@ class BungeePlugin : PlatformPlugin<BungeePluginDescription>("Bungee", "bungee.y
         description.author = description.author ?: project.findProperty("author")?.toString()
     }
 
-    override fun resolve(libraries: Configuration?, description: BungeePluginDescription) {
-        description.libraries = (
-                (description.libraries ?: listOf()) + libraries!!
-                    .resolvedConfiguration
-                    .firstLevelModuleDependencies
-                    .map { it.module.id.toString() }
-                )
+    override fun setLibraries(libraries: ResolvedComponentResult?, description: BungeePluginDescription) {
+        val resolved = libraries?.let {
+            it.dependencies.map { d -> (d as? ResolvedDependencyResult)?.selected?.moduleVersion?.toString() ?: error("No moduleVersion for $d") }
+        }
+        description.libraries = (description.libraries ?: listOf()) + (resolved ?: listOf())
     }
 
     override fun validate(description: BungeePluginDescription) {

--- a/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bungee/BungeePlugin.kt
@@ -45,7 +45,7 @@ class BungeePlugin : PlatformPlugin<BungeePluginDescription>("Bungee", "bungee.y
         val resolved = libraries?.let {
             it.dependencies.map { d -> (d as? ResolvedDependencyResult)?.selected?.moduleVersion?.toString() ?: error("No moduleVersion for $d") }
         }
-        description.libraries = (description.libraries ?: listOf()) + (resolved ?: listOf())
+        description.libraries = ((description.libraries ?: listOf()) + (resolved ?: listOf())).distinct()
     }
 
     override fun validate(description: BungeePluginDescription) {

--- a/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPlugin.kt
@@ -28,6 +28,7 @@ import net.minecrell.pluginyml.InvalidPluginDescriptionException
 import net.minecrell.pluginyml.PlatformPlugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.result.ResolvedComponentResult
 
 class NukkitPlugin : PlatformPlugin<NukkitPluginDescription>("Nukkit", "nukkit.yml") {
     override fun createExtension(project: Project) = NukkitPluginDescription(project)
@@ -44,7 +45,7 @@ class NukkitPlugin : PlatformPlugin<NukkitPluginDescription>("Nukkit", "nukkit.y
         description.author = description.author ?: project.findProperty("author")?.toString()
     }
 
-    override fun resolve(libraries: Configuration?, description: NukkitPluginDescription) {
+    override fun setLibraries(libraries: ResolvedComponentResult?, description: NukkitPluginDescription) {
     }
 
     override fun validate(description: NukkitPluginDescription) {


### PR DESCRIPTION
Without this PR the generate task fails on Gradle 8:
```
> Task :generateBukkitPluginDescription FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':generateBukkitPluginDescription'.
> Cannot fingerprint input property 'librariesConfiguration': value 'configuration ':bukkitLibrary'' cannot be serialized.
```