### PR TITLE
Use Paper's new dependencies format

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ bukkit {
 
 ```kotlin
 plugins {
-    java // or `kotlin("jvm") version "1.8.21"`
+    java // or `kotlin("jvm") version "..."`
     id("net.minecrell.plugin-yml.bukkit") version "0.5.3"
 }
 
@@ -186,8 +186,6 @@ dependencies {
 
     // Make use of classes included by `bootstrapDependencies` and `serverDependencies` sections below
     //   compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.14'
-    // Shadow an implementation using shadow plugin:
-    //   implementation 'dev.samstevens.totp:totp:1.7.1'
 }
 
 paper {
@@ -229,13 +227,13 @@ paper {
 
         // During bootstrap, load BeforePlugin's bootstrap code before ours
         'BeforePlugin' {
-            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+            load = 'BEFORE'
             required = false
             joinClasspath = false
         }
         // During bootstrap, load AfterPlugin's bootstrap code after ours
         'AfterPlugin' {
-            load = PaperPluginDescription.RelativeLoadOrder.AFTER
+            load = 'AFTER'
             required = false
             joinClasspath = false
         }
@@ -244,12 +242,12 @@ paper {
     serverDependencies {
         // During server run time, require LuckPerms, add it to the classpath, and load it before us
         'LuckPerms' {
-            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+            load = 'BEFORE'
         }
 
         // During server run time, require WorldEdit, add it to the classpath, and load it before us
         'WorldEdit' {
-            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+            load = 'BEFORE'
         }
 
         // Optional dependency, add it to classpath if it is available
@@ -287,7 +285,7 @@ import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
 import net.minecrell.pluginyml.paper.PaperPluginDescription
 
 plugins {
-    java // or `kotlin("jvm") version "1.8.21"`
+    java // or `kotlin("jvm") version "..."`
     id("net.minecrell.plugin-yml.paper") version "0.5.3"
 }
 
@@ -306,8 +304,6 @@ dependencies {
 
     // Make use of classes included by `bootstrapDependencies` and `serverDependencies` sections below
     //   compileOnly("com.sk89q.worldedit", "worldedit-bukkit", "7.2.14")
-    // Shadow an implementation using shadow plugin, to create a far jar:
-    //   implementation("dev.samstevens.totp", "totp", "1.7.1")
 }
 
 paper {
@@ -435,7 +431,7 @@ bungee {
 
 ```kotlin
 plugins {
-    java // or `kotlin("jvm") version "1.8.21"`
+    java // or `kotlin("jvm") version "..."`
     id("net.minecrell.plugin-yml.bungee") version "0.5.3"
 }
 
@@ -523,7 +519,7 @@ nukkit {
 
 ```kotlin
 plugins {
-    java // or `kotlin("jvm") version "1.8.21"`
+    java // or `kotlin("jvm") version "..."`
     id("net.minecrell.plugin-yml.nukkit") version "0.5.3"
 }
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ plugins {
     id 'net.minecrell.plugin-yml.paper' version '0.5.3'
 }
 
+repositories {
+    mavenCentral()
+    maven { url "https://papermc.io/repo/repository/maven-public/" }
+}
+
 // NOTE: Paper does not support plugin libraries without additional setup!
 // Please see "Plugin Libraries JSON" in the README for instructions.
 dependencies {
@@ -284,6 +289,11 @@ import net.minecrell.pluginyml.paper.PaperPluginDescription
 plugins {
     java // or `kotlin("jvm") version "1.8.21"`
     id("net.minecrell.plugin-yml.paper") version "0.5.3"
+}
+
+repositories {
+    mavenCentral()
+    maven { url = uri("https://papermc.io/repo/repository/maven-public/") }
 }
 
 // NOTE: Paper does not support plugin libraries without additional setup!

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ import net.minecrell.pluginyml.paper.PaperPluginDescription
 
 plugins {
     id 'java'
-    id 'net.minecrell.plugin-yml.paper' version '0.5.3'
+    id 'net.minecrell.plugin-yml.paper' version '0.6.0-SNAPSHOT'
 }
 
 repositories {
@@ -286,7 +286,7 @@ import net.minecrell.pluginyml.paper.PaperPluginDescription
 
 plugins {
     java // or `kotlin("jvm") version "..."`
-    id("net.minecrell.plugin-yml.paper") version "0.5.3"
+    id("net.minecrell.plugin-yml.paper") version "0.6.0-SNAPSHOT"
 }
 
 repositories {

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ plugins {
 
 dependencies {
     // Downloaded from Maven Central when the plugin is loaded
-    library 'com.google.code.gson:gson:2.8.7' // All platforms
-    bukkitLibrary 'com.google.code.gson:gson:2.8.7' // Bukkit only
+    library 'com.google.code.gson:gson:2.10.1' // All platform plugins
+    bukkitLibrary 'com.google.code.gson:gson:2.10.1' // Bukkit only
 }
 
 bukkit {
@@ -94,14 +94,15 @@ bukkit {
 
 ```kotlin
 plugins {
+    java // or `kotlin("jvm") version "1.8.21"`
     id("net.minecrell.plugin-yml.bukkit") version "0.5.3"
 }
 
 dependencies {
     // Downloaded from Maven Central when the plugin is loaded
-    library(kotlin("stdlib")) // All platforms
-    library("com.google.code.gson", "gson", "2.8.7") // All platforms
-    bukkitLibrary("com.google.code.gson", "gson", "2.8.7") // Bukkit only
+    // library(kotlin("stdlib")) // When using kotlin
+    library("com.google.code.gson", "gson", "2.10.1") // All platform plugins
+    bukkitLibrary("com.google.code.gson", "gson", "2.10.1") // Bukkit only
 }
 
 bukkit {
@@ -163,16 +164,25 @@ bukkit {
 <summary><strong>Groovy</strong></summary>
 
 ```groovy
+import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
+import net.minecrell.pluginyml.paper.PaperPluginDescription
+
 plugins {
-    id 'net.minecrell.plugin-yml.paper' version '0.6.0-SNAPSHOT'
+    id 'java'
+    id 'net.minecrell.plugin-yml.paper' version '0.5.3'
 }
 
 // NOTE: Paper does not support plugin libraries without additional setup!
 // Please see "Plugin Libraries JSON" in the README for instructions.
 dependencies {
     // Downloaded from Maven Central when the plugin is loaded
-    library 'com.google.code.gson:gson:2.8.7' // All platforms
-    paperLibrary 'com.google.code.gson:gson:2.8.7' // Bukkit only
+    library 'com.google.code.gson:gson:2.10.1' // All platform plugins
+    paperLibrary 'com.google.code.gson:gson:2.10.1' // Paper only
+
+    // Make use of classes included by `bootstrapDependencies` and `serverDependencies` sections below
+    //   compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.14'
+    // Shadow an implementation using shadow plugin:
+    //   implementation 'dev.samstevens.totp:totp:1.7.1'
 }
 
 paper {
@@ -191,7 +201,7 @@ paper {
     loader = 'com.example.testplugin.loader.TestPluginLoader'
     hasOpenClassloader = false
 
-    // generate paper-libraries.json?
+    // Generate paper-libraries.json from `library` and `paperLibrary` in `dependencies`
     generateLibrariesJson = true
 
     // Mark plugin for supporting Folia
@@ -207,22 +217,45 @@ paper {
     prefix = 'TEST'
     provides = ['TestPluginOldName', 'TestPlug']
 
-    depends {
-        'WorldEdit' {
-            required : true
-            bootstrap: true
-        }
-        'Essentials' {
-        }
-    }
-    loadBefore {
+    // Bootstrap dependencies - Very rarely needed
+    bootstrapDependencies {
+        // Required dependency during bootstrap
+        'WorldEdit' {}
+
+        // During bootstrap, load BeforePlugin's bootstrap code before ours
         'BeforePlugin' {
-            bootstrap: true
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+            required = false
+            joinClasspath = false
+        }
+        // During bootstrap, load AfterPlugin's bootstrap code after ours
+        'AfterPlugin' {
+            load = PaperPluginDescription.RelativeLoadOrder.AFTER
+            required = false
+            joinClasspath = false
         }
     }
-    loadAfter {
-        'AfterPlugin' {
-            bootstrap: true
+
+    serverDependencies {
+        // During server run time, require LuckPerms, add it to the classpath, and load it before us
+        'LuckPerms' {
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+        }
+
+        // During server run time, require WorldEdit, add it to the classpath, and load it before us
+        'WorldEdit' {
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+        }
+
+        // Optional dependency, add it to classpath if it is available
+        'ProtocolLib' {
+            required = false
+        }
+
+        // During server run time, optionally depend on Essentials but do not add it to the classpath
+        'Essentials' {
+            required = false
+            joinClasspath = false
         }
     }
 
@@ -245,7 +278,11 @@ paper {
 <summary><strong>kotlin-dsl</strong></summary>
 
 ```kotlin
+import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
+import net.minecrell.pluginyml.paper.PaperPluginDescription
+
 plugins {
+    java // or `kotlin("jvm") version "1.8.21"`
     id("net.minecrell.plugin-yml.paper") version "0.5.3"
 }
 
@@ -253,9 +290,14 @@ plugins {
 // Please see "Plugin Libraries JSON" in the README for instructions.
 dependencies {
     // Downloaded from Maven Central when the plugin is loaded
-    library(kotlin("stdlib")) // All platforms
-    library("com.google.code.gson", "gson", "2.8.7") // All platforms
-    paperLibrary("com.google.code.gson", "gson", "2.8.7") // Bukkit only
+    // library(kotlin("stdlib")) // When using kotlin
+    library("com.google.code.gson", "gson", "2.10.1") // All platform plugins
+    paperLibrary("com.google.code.gson", "gson", "2.10.1") // Paper only
+
+    // Make use of classes included by `bootstrapDependencies` and `serverDependencies` sections below
+    //   compileOnly("com.sk89q.worldedit", "worldedit-bukkit", "7.2.14")
+    // Shadow an implementation using shadow plugin, to create a far jar:
+    //   implementation("dev.samstevens.totp", "totp", "1.7.1")
 }
 
 paper {
@@ -274,7 +316,7 @@ paper {
     loader = "com.example.testplugin.loader.TestPluginLoader"
     hasOpenClassloader = false
 
-    // generate paper-libraries.json?
+    // Generate paper-libraries.json from `library` and `paperLibrary` in `dependencies`
     generateLibrariesJson = true
 
     // Mark plugin for supporting Folia
@@ -291,24 +333,42 @@ paper {
     defaultPermission = BukkitPluginDescription.Permission.Default.OP // TRUE, FALSE, OP or NOT_OP
     provides = listOf("TestPluginOldName", "TestPlug")
 
-    depends {
-        // Required dependency
-        register("WorldEdit") {
-            required = true
-            bootstrap = true
-        }
-        // Optional dependency
-        register("Essentials") {
-        }
-    }
-    loadBefore {
+    bootstrapDependencies {
+        // Required dependency during bootstrap
+        register("WorldEdit")
+
+        // During bootstrap, load BeforePlugin's bootstrap code before ours
         register("BeforePlugin") {
-            bootstrap = true
+            required = false
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+        }
+        // During bootstrap, load AfterPlugin's bootstrap code after ours
+        register("AfterPlugin") {
+            required = false
+            load = PaperPluginDescription.RelativeLoadOrder.AFTER
         }
     }
-    loadAfter {
-        register("AfterPlugin") {
-            bootstrap = true
+
+    serverDependencies {
+        // During server run time, require LuckPerms, add it to the classpath, and load it before us
+        register("LuckPerms") {
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+        }
+
+        // During server run time, require WorldEdit, add it to the classpath, and load it before us
+        register("WorldEdit") {
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+        }
+
+        // Optional dependency, add it to classpath if it is available
+        register("ProtocolLib") {
+            required = false
+        }
+
+        // During server run time, optionally depend on Essentials but do not add it to the classpath
+        register("Essentials") {
+            required = false
+            joinClasspath = false
         }
     }
 
@@ -320,7 +380,7 @@ paper {
         }
         register("testplugin.test") {
             description = "Allows you to run the test command"
-            default = PaperPluginDescription.Permission.Default.OP // TRUE, FALSE, OP or NOT_OP
+            default = BukkitPluginDescription.Permission.Default.OP // TRUE, FALSE, OP or NOT_OP
         }
     }
 }
@@ -339,8 +399,8 @@ plugins {
 
 dependencies {
     // Downloaded from Maven Central when the plugin is loaded
-    library 'com.google.code.gson:gson:2.8.7' // All platforms
-    bungeeLibrary 'com.google.code.gson:gson:2.8.7' // Bungee only
+    library 'com.google.code.gson:gson:2.10.1' // All platform plugins
+    bungeeLibrary 'com.google.code.gson:gson:2.10.1' // Bungee only
 }
 
 bungee {
@@ -365,14 +425,15 @@ bungee {
 
 ```kotlin
 plugins {
+    java // or `kotlin("jvm") version "1.8.21"`
     id("net.minecrell.plugin-yml.bungee") version "0.5.3"
 }
 
 dependencies {
     // Downloaded from Maven Central when the plugin is loaded
-    library(kotlin("stdlib")) // All platforms
-    library("com.google.code.gson", "gson", "2.8.7") // All platforms
-    bungeeLibrary("com.google.code.gson", "gson", "2.8.7") // Bungee only
+    // library(kotlin("stdlib")) // When using kotlin
+    library("com.google.code.gson", "gson", "2.10.1") // All platform plugins
+    bungeeLibrary("com.google.code.gson", "gson", "2.10.1") // Bungee only
 }
 
 bungee {
@@ -452,6 +513,7 @@ nukkit {
 
 ```kotlin
 plugins {
+    java // or `kotlin("jvm") version "1.8.21"`
     id("net.minecrell.plugin-yml.nukkit") version "0.5.3"
 }
 
@@ -509,7 +571,7 @@ can export them in a `paper-libraries.json` / `nukkit-libraries.json` file with 
 ```json
 {
     "repositories": {"MavenRepo": "https://repo.maven.apache.org/maven2/"},
-    "dependencies": ["com.google.code.gson:gson:2.8.5"]
+    "dependencies": ["com.google.code.gson:gson:2.10.1"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -164,9 +164,6 @@ bukkit {
 <summary><strong>Groovy</strong></summary>
 
 ```groovy
-import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
-import net.minecrell.pluginyml.paper.PaperPluginDescription
-
 plugins {
     id 'java'
     id 'net.minecrell.plugin-yml.paper' version '0.6.0-SNAPSHOT'

--- a/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPlugin.kt
@@ -64,16 +64,11 @@ class PaperPlugin : PlatformPlugin<PaperPluginDescription>("Paper", "paper-plugi
         validateNamespace(description.bootstrapper, "Bootstrapper")
         validateNamespace(description.loader, "Loader")
 
-        for (before in description.loadBefore) {
-            if (before.name.isEmpty()) throw InvalidPluginDescriptionException("Plugin name in loadBefore can not be empty")
+        for (serverDependency in description.serverDependencies) {
+            if (serverDependency.name.isEmpty()) throw InvalidPluginDescriptionException("Plugin name in serverDependencies can not be empty")
         }
-
-        for (after in description.loadAfter) {
-            if (after.name.isEmpty()) throw InvalidPluginDescriptionException("Plugin name in loadAfter can not be empty")
-        }
-
-        for (depend in description.depends) {
-            if (depend.name.isEmpty()) throw InvalidPluginDescriptionException("Plugin name in depends can not be empty")
+        for (bootstrapDependency in description.bootstrapDependencies) {
+            if (bootstrapDependency.name.isEmpty()) throw InvalidPluginDescriptionException("Plugin name in bootstrapDependencies can not be empty")
         }
 
         if (description.provides?.all(VALID_NAME::matches) == false) {

--- a/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
@@ -55,7 +55,7 @@ class PaperPluginDescription(project: Project) : PluginDescription() {
     @Input @Optional var contributors: List<String>? = null
     @Input @Optional var website: String? = null
     @Input @Optional var prefix: String? = null
-    @Input @Optional var defaultPermission: Permission.Default? = null
+    @Input @Optional @JsonProperty("defaultPerm") var defaultPermission: Permission.Default? = null
     @Input @Optional var provides: List<String>? = null
     @Input @Optional var hasOpenClassloader: Boolean? = null
     @Input @Optional var foliaSupported: Boolean? = null

--- a/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
@@ -24,6 +24,7 @@
 
 package net.minecrell.pluginyml.paper
 
+import com.fasterxml.jackson.annotation.JsonGetter
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
@@ -62,7 +63,7 @@ class PaperPluginDescription(project: Project) : PluginDescription() {
     @Nested @Optional @JsonIgnore
     var bootstrapDependencies: NamedDomainObjectContainer<DependencyDefinition> = project.container(DependencyDefinition::class.java)
 
-    @JsonProperty("dependencies")
+    @JsonGetter
     fun dependencies(): Map<String, NamedDomainObjectContainer<DependencyDefinition>> = mapOf(
         "server" to serverDependencies,
         "bootstrap" to bootstrapDependencies,

--- a/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
@@ -62,7 +62,7 @@ class PaperPluginDescription(project: Project) : PluginDescription() {
     @Nested @Optional @JsonIgnore
     var bootstrapDependencies: NamedDomainObjectContainer<DependencyDefinition> = project.container(DependencyDefinition::class.java)
 
-    @JsonProperty("dependencies") @JsonSerialize(contentAs = Collection::class)
+    @JsonProperty("dependencies")
     fun dependencies(): Map<String, NamedDomainObjectContainer<DependencyDefinition>> = mapOf(
         "server" to serverDependencies,
         "bootstrap" to bootstrapDependencies,
@@ -75,7 +75,7 @@ class PaperPluginDescription(project: Project) : PluginDescription() {
     fun serverDependencies(closure: Closure<Unit>) = serverDependencies.configure(closure)
     fun bootstrapDependencies(closure: Closure<Unit>) = bootstrapDependencies.configure(closure)
 
-    data class DependencyDefinition(@Input val name: String) {
+    data class DependencyDefinition(@Input @JsonIgnore val name: String) {
         @Input var load: RelativeLoadOrder = RelativeLoadOrder.OMIT
         @Input var required: Boolean = true
         @Input var joinClasspath: Boolean = true

--- a/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
@@ -27,7 +27,9 @@ package net.minecrell.pluginyml.paper
 import com.fasterxml.jackson.annotation.JsonGetter
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy
 import groovy.lang.Closure
 import net.minecrell.pluginyml.PluginDescription
 import net.minecrell.pluginyml.bukkit.BukkitPluginDescription.Permission
@@ -38,9 +40,9 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 
+@JsonNaming(KebabCaseStrategy::class)
 class PaperPluginDescription(project: Project) : PluginDescription() {
-
-    @Input @JsonProperty("api-version") var apiVersion: String? = null
+    @Input var apiVersion: String? = null
     @Input var name: String? = null
     @Input var version: String? = null
     @Input var main: String? = null
@@ -53,10 +55,10 @@ class PaperPluginDescription(project: Project) : PluginDescription() {
     @Input @Optional var contributors: List<String>? = null
     @Input @Optional var website: String? = null
     @Input @Optional var prefix: String? = null
-    @Input @Optional @JsonProperty("defaultPerm") var defaultPermission: Permission.Default? = null
+    @Input @Optional var defaultPermission: Permission.Default? = null
     @Input @Optional var provides: List<String>? = null
-    @Input @Optional @JsonProperty("has-open-classloader") var hasOpenClassloader: Boolean? = null
-    @Input @Optional @JsonProperty("folia-supported") var foliaSupported: Boolean? = null
+    @Input @Optional var hasOpenClassloader: Boolean? = null
+    @Input @Optional var foliaSupported: Boolean? = null
 
     @Nested @Optional @JsonIgnore
     var serverDependencies: NamedDomainObjectContainer<DependencyDefinition> = project.container(DependencyDefinition::class.java)


### PR DESCRIPTION
Original work to get Paper Plugins support added: #30

From PaperMC announcements: 

<details>
  <summary>Click here to read the announcement</summary>

> 2023-06-07, PaperMC discord #dev-announcements
> 
> ## Dependency Format Update
> 
> Dependency declaration has been update for paper plugins to better represent the different lifecycles in Paper plugins.
> Note, the previous format is scheduled for removal in 1.21.
> 
> Most noteably with this new format is that specifying load order is now relative to the dependency rather than the plugin as a whole. 
> 
> So for example, marking a dependency with `load: BEFORE` will now cause the dependency to load BEFORE your plugin.
> 
> **Before**
> 
> ```yaml
> load-before:
>   - name: RequiredPlugin
>     bootstrap: false
> load-after:
>   - name: RegistryPlugin
>     bootstrap: true
>   - name: OtherPlugin
>     bootstrap: false
> dependencies:
>   - name: OtherPlugin
>     required: false
>     bootstrap: false
>   - name: RegistryPlugin
>     required: true
>     bootstrap: true
> ```
> 
> **After**
> 
> ```yaml
> dependencies:
>   bootstrap:
>     # Lets say that RegistryPlugin has some registry elements that this plugin requires.
>     # We don't need this during runtime, so it's not required in the server section. However
>     # can be added to both if needed
>     RegistryPlugin:
>       load: BEFORE 
>       required: true
>       # (this is default)
>       join-classpath: true
>   server:
>     # Add a required "RequiredPlugin" dependency, which will load AFTER your plugin.
>     RequiredPlugin:
>       load: AFTER
>       required: true
>       # This means that this plugin won't have access to classpath
>       join-classpath: false
>     # Add "OtherPlugin" dependency, which will load BEFORE your plugin. WILL join classpath (by default)
>     OtherPlugin:
>       load: BEFORE
>       required: false
>       join-classpath: true
>     # Load order can be omitted to cause it to be ignored... or specified by load-order: OMIT
>     SpecialDependency:
>       required: true
>       join-classpath: true
> ```

</details>

I've implemented this new format in `plugin-yml`. Here is the syntax: 

**kotlin**
```kotlin
paper {
    [...]
    bootstrapDependencies {
        // Required dependency during bootstrap
        register("WorldEdit")

        // During bootstrap, load BeforePlugin's bootstrap code before ours
        register("BeforePlugin") {
            required = false
            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
        }
        // During bootstrap, load AfterPlugin's bootstrap code after ours
        register("AfterPlugin") {
            required = false
            load = PaperPluginDescription.RelativeLoadOrder.AFTER
        }
    }

    serverDependencies {
        // During server run time, require LuckPerms, add it to the classpath, and load it before us
        register("LuckPerms") {
            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
        }

        // During server run time, require WorldEdit, add it to the classpath, and load it before us
        register("WorldEdit") {
            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
        }

        // Optional dependency, add it to classpath if it is available
        register("ProtocolLib") {
            required = false
        }

        // During server run time, optionally depend on Essentials but do not add it to the classpath
        register("Essentials") {
            required = false
            joinClasspath = false
        }
    }
}
```

**groovy**
```groovy
paper {
    [...]
    bootstrapDependencies {
        // Required dependency during bootstrap
        'WorldEdit' {}

        // During bootstrap, load BeforePlugin's bootstrap code before ours
        'BeforePlugin' {
            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
            required = false
            joinClasspath = false
        }
        // During bootstrap, load AfterPlugin's bootstrap code after ours
        'AfterPlugin' {
            load = PaperPluginDescription.RelativeLoadOrder.AFTER
            required = false
            joinClasspath = false
        }
    }

    serverDependencies {
        // During server run time, require LuckPerms, add it to the classpath, and load it before us
        'LuckPerms' {
            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
        }

        // During server run time, require WorldEdit, add it to the classpath, and load it before us
        'WorldEdit' {
            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
        }

        // Optional dependency, add it to classpath if it is available
        'ProtocolLib' {
            required = false
        }

        // During server run time, optionally depend on Essentials but do not add it to the classpath
        'Essentials' {
            required = false
            joinClasspath = false
        }
    }
}
```

One other option is to have it nested the same way it is in the `.yml` file:

```kotlin
paper {
    dependencies {
        bootstrap {

        }
        server {

        }
    }
}
```

But I found the `serverDependencies` and `bootstrapDependencies` option to be nicer, less pointless indentation. Most people will never even need bootstrap dependencies, so it makes sense to keep it clean.

Anyways, I also edited the README to change the examples to specify Java as the project programming language, as this is required for these examples to actually compile.