### PR TITLE
Add basis of command-support for Paper plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ paper {
         }
     }
 
+    commands {
+        register("test") {
+            description = "This is a test command!"
+            aliases = listOf("t")
+            permission = "testplugin.test"
+            usage = "Just run the command!"
+            // permissionMessage = "You may not test this command!"
+        }
+        // ...
+    }
+
     permissions {
         'testplugin.*' {
             children = ['testplugin.test'] // Defaults permissions to true

--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ paper {
     }
 
     commands {
-<<<<<<< HEAD
         test {
             description = 'This is a test command!'
             aliases = ['t']
@@ -271,18 +270,6 @@ paper {
         // ...
     }
     
-=======
-        register("test") {
-            description = "This is a test command!"
-            aliases = listOf("t")
-            permission = "testplugin.test"
-            usage = "Just run the command!"
-            // permissionMessage = "You may not test this command!"
-        }
-        // ...
-    }
-
->>>>>>> impl-paper-commands
     permissions {
         'testplugin.*' {
             children = ['testplugin.test'] // Defaults permissions to true

--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ paper {
         }
     }
 
+    commands {
+        test {
+            description = 'This is a test command!'
+            aliases = ['t']
+            permission = 'testplugin.test'
+            usage = 'Just run the command!'
+            // permissionMessage = 'You may not test this command!'
+        }
+        // ...
+    }
+    
     permissions {
         'testplugin.*' {
             children = ['testplugin.test'] // Defaults permissions to true
@@ -373,6 +384,17 @@ paper {
             required = false
             joinClasspath = false
         }
+    }
+
+    commands {
+        register("test") {
+            description = "This is a test command!"
+            aliases = listOf("t")
+            permission = "testplugin.test"
+            usage = "Just run the command!"
+            // permissionMessage = "You may not test this command!"
+        }
+        // ...
     }
 
     permissions {

--- a/src/main/kotlin/net/minecrell/pluginyml/PluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/PluginDescription.kt
@@ -28,5 +28,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import org.gradle.api.tasks.Input
 
 abstract class PluginDescription {
-    @Input @JsonIgnore var generateLibrariesJson: Boolean = false
+    @Input
+    @JsonIgnore
+    var generateLibrariesJson: Boolean = false
 }

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPlugin.kt
@@ -27,13 +27,15 @@ package net.minecrell.pluginyml.bukkit
 import net.minecrell.pluginyml.InvalidPluginDescriptionException
 import net.minecrell.pluginyml.PlatformPlugin
 import net.minecrell.pluginyml.collectLibraries
+import net.minecrell.pluginyml.common.validate
 import org.gradle.api.Project
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 
 class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.yml") {
 
     companion object {
-        @JvmStatic private val VALID_NAME = Regex("^[A-Za-z0-9 _.-]+$")
+        @JvmStatic
+        private val VALID_NAME = Regex("^[A-Za-z0-9 _.-]+$")
     }
 
     override fun createExtension(project: Project) = BukkitPluginDescription(project)
@@ -60,12 +62,7 @@ class BukkitPlugin : PlatformPlugin<BukkitPluginDescription>("Bukkit", "plugin.y
         if (main.isEmpty()) throw InvalidPluginDescriptionException("Main class cannot be empty")
         if (main.startsWith("org.bukkit.")) throw InvalidPluginDescriptionException("Main may not be within the org.bukkit namespace")
 
-        for (command in description.commands) {
-            if (command.name.contains(':')) throw InvalidPluginDescriptionException("Command '${command.name}' cannot contain ':'")
-            command.aliases?.forEach { alias ->
-                if (alias.contains(':')) throw InvalidPluginDescriptionException("Alias '$alias' of '${command.name}' cannot contain ':'")
-            }
-        }
+        description.commands.validate()
 
         if (description.provides?.all(VALID_NAME::matches) == false) {
             throw InvalidPluginDescriptionException("Invalid plugin provides name: all should match $VALID_NAME")

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.lang.Closure
 import net.minecrell.pluginyml.PluginDescription
+import net.minecrell.pluginyml.common.Command
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
@@ -66,14 +67,6 @@ class BukkitPluginDescription(project: Project) : PluginDescription() {
     enum class PluginLoadOrder {
         STARTUP,
         POSTWORLD
-    }
-
-    data class Command(@Input @JsonIgnore val name: String) {
-        @Input @Optional var description: String? = null
-        @Input @Optional var aliases: List<String>? = null
-        @Input @Optional var permission: String? = null
-        @Input @Optional @JsonProperty("permission-message") var permissionMessage: String? = null
-        @Input @Optional var usage: String? = null
     }
 
     data class Permission(@Input @JsonIgnore val name: String) {

--- a/src/main/kotlin/net/minecrell/pluginyml/common/Command.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/common/Command.kt
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package net.minecrell.pluginyml.common
 
 import com.fasterxml.jackson.annotation.JsonIgnore

--- a/src/main/kotlin/net/minecrell/pluginyml/common/Command.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/common/Command.kt
@@ -1,0 +1,39 @@
+package net.minecrell.pluginyml.common
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+data class Command(@Input @JsonIgnore val name: String) {
+
+    @Input
+    @Optional
+    var description: String? = null
+
+    @Input
+    @Optional
+    var aliases: List<String>? = null
+
+    @Input
+    @Optional
+    var permission: String? = null
+
+    @Input
+    @Optional
+    @JsonProperty("permission-message")
+    var permissionMessage: String? = null
+
+    @Input
+    @Optional
+    var usage: String? = null
+}
+
+/* original from BukkitPluginDescription
+data class Command(@Input @JsonIgnore val name: String) {
+    @Input @Optional var description: String? = null
+    @Input @Optional var aliases: List<String>? = null
+    @Input @Optional var permission: String? = null
+    @Input @Optional @JsonProperty("permission-message") var permissionMessage: String? = null
+    @Input @Optional var usage: String? = null
+} */

--- a/src/main/kotlin/net/minecrell/pluginyml/common/Extensions.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/common/Extensions.kt
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package net.minecrell.pluginyml.common
 
 import net.minecrell.pluginyml.InvalidPluginDescriptionException

--- a/src/main/kotlin/net/minecrell/pluginyml/common/Extensions.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/common/Extensions.kt
@@ -1,0 +1,26 @@
+package net.minecrell.pluginyml.common
+
+import net.minecrell.pluginyml.InvalidPluginDescriptionException
+import org.gradle.api.NamedDomainObjectContainer
+
+fun NamedDomainObjectContainer<Command>.validate() = this.forEach { command ->
+    if (command.name.contains(":"))
+        throw InvalidPluginDescriptionException("Command '${command.name}' cannot contain ':'.")
+
+    command.aliases?.forEach { alias ->
+        if (alias.contains(":"))
+            throw InvalidPluginDescriptionException("Alias '$alias' of '${command.name}' cannot contain ':'.")
+    }
+}
+
+/* fun PluginDescription.validateCommands(nestedDomainObjectContainer: NamedDomainObjectContainer<Command>) {
+    for (command in nestedDomainObjectContainer) {
+        if (command.name.contains(":"))
+            throw InvalidPluginDescriptionException("Command '${command.name}' cannot contain ':'.")
+
+        command.aliases?.forEach {
+            if (it.contains(":"))
+                throw InvalidPluginDescriptionException("Alias '$it' of '${command.name}' cannot contain ':'.")
+        }
+    }
+} */

--- a/src/main/kotlin/net/minecrell/pluginyml/common/Permission.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/common/Permission.kt
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package net.minecrell.pluginyml.common
 
 import com.fasterxml.jackson.annotation.JsonIgnore

--- a/src/main/kotlin/net/minecrell/pluginyml/common/Permission.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/common/Permission.kt
@@ -1,0 +1,56 @@
+package net.minecrell.pluginyml.common
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import groovy.lang.Closure
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+
+class Permission(@Input @JsonIgnore val name: String, project: Project) {
+
+    @Input
+    @Optional
+    var description: String? = null
+    @Input
+    @Optional
+    var default: Default? = null
+
+    @Nested
+    val children: NamedDomainObjectContainer<Permission> = project.container(Permission::class.java)
+
+    // For Groovy DSL
+    fun children(closure: Closure<Unit>) = children.configure(closure)
+
+    enum class Default {
+        @JsonProperty("true")
+        TRUE,
+        @JsonProperty("false")
+        FALSE,
+        @JsonProperty("op")
+        OP,
+        @JsonProperty("!op")
+        NOT_OP
+    }
+}
+
+/* original from NukkitPluginDescription
+class Permission(@Input @JsonIgnore val name: String, project: Project) {
+
+    @Input @Optional var description: String? = null
+    @Input @Optional var default: Default? = null
+
+    @Nested val children: NamedDomainObjectContainer<Permission> = project.container(Permission::class.java)
+
+    // For Groovy DSL
+    fun children(closure: Closure<Unit>) = children.configure(closure)
+
+    enum class Default {
+        @JsonProperty("true")   TRUE,
+        @JsonProperty("false")  FALSE,
+        @JsonProperty("op")     OP,
+        @JsonProperty("!op")    NOT_OP
+    }
+}*/

--- a/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPlugin.kt
@@ -26,6 +26,7 @@ package net.minecrell.pluginyml.nukkit
 
 import net.minecrell.pluginyml.InvalidPluginDescriptionException
 import net.minecrell.pluginyml.PlatformPlugin
+import net.minecrell.pluginyml.common.validate
 import org.gradle.api.Project
 
 class NukkitPlugin : PlatformPlugin<NukkitPluginDescription>("Nukkit", "nukkit.yml") {
@@ -49,12 +50,6 @@ class NukkitPlugin : PlatformPlugin<NukkitPluginDescription>("Nukkit", "nukkit.y
 
         if (description.api.isNullOrEmpty()) throw InvalidPluginDescriptionException("Nukkit API version is not set")
 
-        for (command in description.commands) {
-            if (command.name.contains(':')) throw InvalidPluginDescriptionException("Command '${command.name}' cannot contain ':'")
-            command.aliases?.forEach { alias ->
-                if (alias.contains(':')) throw InvalidPluginDescriptionException("Alias '$alias' of '${command.name}' cannot contain ':'")
-            }
-        }
+        description.commands.validate()
     }
-
 }

--- a/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/nukkit/NukkitPluginDescription.kt
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.lang.Closure
 import net.minecrell.pluginyml.PluginDescription
+import net.minecrell.pluginyml.common.Command
+import net.minecrell.pluginyml.common.Permission
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
@@ -61,31 +63,4 @@ class NukkitPluginDescription(project: Project) : PluginDescription() {
         STARTUP,
         POSTWORLD
     }
-
-    data class Command(@Input @JsonIgnore val name: String) {
-        @Input @Optional var description: String? = null
-        @Input @Optional var aliases: List<String>? = null
-        @Input @Optional var permission: String? = null
-        @Input @Optional @JsonProperty("permission-message") var permissionMessage: String? = null
-        @Input @Optional var usage: String? = null
-    }
-
-    class Permission(@Input @JsonIgnore val name: String, project: Project) {
-
-        @Input @Optional var description: String? = null
-        @Input @Optional var default: Default? = null
-
-        @Nested val children: NamedDomainObjectContainer<Permission> = project.container(Permission::class.java)
-
-        // For Groovy DSL
-        fun children(closure: Closure<Unit>) = children.configure(closure)
-
-        enum class Default {
-            @JsonProperty("true")   TRUE,
-            @JsonProperty("false")  FALSE,
-            @JsonProperty("op")     OP,
-            @JsonProperty("!op")    NOT_OP
-        }
-    }
-
 }

--- a/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPlugin.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPlugin.kt
@@ -26,6 +26,7 @@ package net.minecrell.pluginyml.paper
 
 import net.minecrell.pluginyml.InvalidPluginDescriptionException
 import net.minecrell.pluginyml.PlatformPlugin
+import net.minecrell.pluginyml.common.validate
 import org.gradle.api.Project
 
 class PaperPlugin : PlatformPlugin<PaperPluginDescription>("Paper", "paper-plugin.yml") {
@@ -33,9 +34,9 @@ class PaperPlugin : PlatformPlugin<PaperPluginDescription>("Paper", "paper-plugi
     companion object {
         @JvmStatic
         private val VALID_NAME = Regex("^[A-Za-z0-9 _.-]+$")
+
         @JvmStatic
         private val INVALID_NAMESPACES = listOf("net.minecraft.", "org.bukkit.", "io.papermc.paper.", "com.destroystokoyo.paper.")
-
     }
 
     override fun createExtension(project: Project) = PaperPluginDescription(project)
@@ -63,6 +64,8 @@ class PaperPlugin : PlatformPlugin<PaperPluginDescription>("Paper", "paper-plugi
         validateNamespace(description.main, "Main")
         validateNamespace(description.bootstrapper, "Bootstrapper")
         validateNamespace(description.loader, "Loader")
+
+        description.commands.validate()
 
         for (serverDependency in description.serverDependencies) {
             if (serverDependency.name.isEmpty()) throw InvalidPluginDescriptionException("Plugin name in serverDependencies can not be empty")

--- a/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/paper/PaperPluginDescription.kt
@@ -33,6 +33,7 @@ import groovy.lang.Closure
 import net.minecrell.pluginyml.PluginDescription
 import net.minecrell.pluginyml.bukkit.BukkitPluginDescription.Permission
 import net.minecrell.pluginyml.bukkit.BukkitPluginDescription.PluginLoadOrder
+import net.minecrell.pluginyml.common.Command
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
@@ -41,6 +42,7 @@ import org.gradle.api.tasks.Optional
 
 @JsonNaming(KebabCaseStrategy::class)
 class PaperPluginDescription(project: Project) : PluginDescription() {
+
     @Input var apiVersion: String? = null
     @Input var name: String? = null
     @Input var version: String? = null
@@ -59,8 +61,12 @@ class PaperPluginDescription(project: Project) : PluginDescription() {
     @Input @Optional var hasOpenClassloader: Boolean? = null
     @Input @Optional var foliaSupported: Boolean? = null
 
+    @Nested val commands: NamedDomainObjectContainer<Command> = project.container(Command::class.java)
+    @Nested val permissions: NamedDomainObjectContainer<Permission> = project.container(Permission::class.java)
+
     @Nested @Optional @JsonIgnore
     var serverDependencies: NamedDomainObjectContainer<DependencyDefinition> = project.container(DependencyDefinition::class.java)
+
     @Nested @Optional @JsonIgnore
     var bootstrapDependencies: NamedDomainObjectContainer<DependencyDefinition> = project.container(DependencyDefinition::class.java)
 
@@ -70,9 +76,8 @@ class PaperPluginDescription(project: Project) : PluginDescription() {
         "bootstrap" to bootstrapDependencies,
     )
 
-    @Nested val permissions: NamedDomainObjectContainer<Permission> = project.container(Permission::class.java)
-
     // For Groovy DSL
+    fun commands(closure: Closure<Unit>) = commands.configure(closure)
     fun permissions(closure: Closure<Unit>) = permissions.configure(closure)
     fun serverDependencies(closure: Closure<Unit>) = serverDependencies.configure(closure)
     fun bootstrapDependencies(closure: Closure<Unit>) = bootstrapDependencies.configure(closure)
@@ -89,5 +94,4 @@ class PaperPluginDescription(project: Project) : PluginDescription() {
         AFTER,
         OMIT,
     }
-
 }


### PR DESCRIPTION
- Some parts of the code were rearranged or removed to reduce the amount of duplications and the size of the plugin.
- I combined the code that validates the commands into one extension to also reduce the number of duplicates and the size of the plugin.
