### PR TITLE
feat: no libraries section

### DIFF
--- a/src/main/kotlin/net/minecrell/pluginyml/GeneratePluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/GeneratePluginDescription.kt
@@ -33,6 +33,8 @@ import com.fasterxml.jackson.databind.util.StdConverter
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import net.minecrell.pluginyml.bukkit.BukkitPlugin
+import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
 import org.gradle.api.DefaultTask
 import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
@@ -83,7 +85,17 @@ abstract class GeneratePluginDescription : DefaultTask() {
             .registerModule(module)
             .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
         val pluginDescription = pluginDescription.get()
+        val librariesBak: List<String>?
+        if (pluginDescription is BukkitPluginDescription && pluginDescription.noLibrariesSection) {
+            librariesBak = pluginDescription.libraries
+            pluginDescription.libraries = null
+        } else {
+            librariesBak = null
+        }
         mapper.writeValue(outputDirectory.file(fileName).get().asFile, pluginDescription)
+        if (librariesBak != null) {
+            (pluginDescription as BukkitPluginDescription).libraries = librariesBak
+        }
 
         if (pluginDescription.generateLibrariesJson) {
             val repos = this.project.repositories.withType(MavenArtifactRepository::class.java)

--- a/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
+++ b/src/main/kotlin/net/minecrell/pluginyml/bukkit/BukkitPluginDescription.kt
@@ -56,6 +56,8 @@ class BukkitPluginDescription(project: Project) : PluginDescription() {
     @Input @Optional var libraries: List<String>? = null
     @Input @Optional @JsonProperty("folia-supported") var foliaSupported: Boolean? = null
 
+    @Input @JsonIgnore var noLibrariesSection: Boolean = false
+
     @Nested val commands: NamedDomainObjectContainer<Command> = project.container(Command::class.java)
     @Nested val permissions: NamedDomainObjectContainer<Permission> = project.container(Permission::class.java)
 


### PR DESCRIPTION
We may use an alternative solution for runtime dependency management, so we don't need Spigot to load libraries for us at this time. We just need libraries.json